### PR TITLE
Using Cratis version 2.13.6

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -24,7 +24,7 @@
         <Autofac>6.2.0</Autofac>
         <AutofacExtensions>7.1.0</AutofacExtensions>
         <MongoDB>2.13.1</MongoDB>
-        <Cratis>2.13.5</Cratis>
+        <Cratis>2.13.6</Cratis>
     </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Fixed

- Pulling in version 2.13.6 of Cratis with support for concepts in the change comparer.
