### PR TITLE
Version 2.13.7 of Cratis - hoping PropertyDifference is OK now

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -24,7 +24,7 @@
         <Autofac>6.2.0</Autofac>
         <AutofacExtensions>7.1.0</AutofacExtensions>
         <MongoDB>2.13.1</MongoDB>
-        <Cratis>2.13.6</Cratis>
+        <Cratis>2.13.7</Cratis>
     </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Fixed

- Looks like the change in v2.13.6 of Cratis actually wasn't published - going for v2.13.7 for the PropertyDifference fix for concepts.
